### PR TITLE
Add support for responsive images

### DIFF
--- a/s3-media-storage.php
+++ b/s3-media-storage.php
@@ -94,11 +94,7 @@ class S3MS {
         }
 
         $upload_dir = wp_upload_dir();
-
-        $file = str_replace($upload_dir['baseurl'], '', $url);
-        if (substr($file, 0, 1) == '/') {
-            $file = substr($file, 1);
-        }
+        $file = str_replace( trailingslashit($upload_dir['baseurl']), '', $url );
 
         // $file = isset($custom_fields['S3MS_file']) ? $custom_fields['S3MS_file'][0] : null;
         $cloudfront = isset($custom_fields['S3MS_cloudfront']) ? $custom_fields['S3MS_cloudfront'][0] : null;

--- a/s3-media-storage.php
+++ b/s3-media-storage.php
@@ -106,10 +106,7 @@ class S3MS {
         } elseif ($settings['s3_protocol'] == 'https') {
             $protocol = 'https://';
         } elseif ($settings['s3_protocol'] == 'relative') {
-            $protocol = 'http://';
-            if (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] === '443') {
-                $protocol = 'https://';
-            }
+            $protocol = 'http' . (is_ssl() ? 's' : '') . '://';
         } else {
             $protocol = 'https://';
         }


### PR DESCRIPTION
WordPress 4.4 introduced srcset attribute on all images published with WordPress. However it works slightly different from single attachments and therefore requires URLs in srcset to be adjusted.

Fixes https://github.com/agentile/S3-Media-Storage/issues/18
